### PR TITLE
Create GanysSurface.zs

### DIFF
--- a/scripts/GanysSurface.zs
+++ b/scripts/GanysSurface.zs
@@ -1,0 +1,17 @@
+## Ganys Surface
+
+recipes.remove(<ganyssurface:colouredRedstone>);
+recipes.remove(<ganyssurface:colouredRedstone:2>);
+recipes.remove(<ganyssurface:colouredRedstone:3>);
+recipes.remove(<ganyssurface:colouredRedstone:4>);
+recipes.remove(<ganyssurface:colouredRedstone:5>);
+recipes.remove(<ganyssurface:colouredRedstone:6>);
+recipes.remove(<ganyssurface:colouredRedstone:7>);
+recipes.remove(<ganyssurface:colouredRedstone:8>);
+recipes.remove(<ganyssurface:colouredRedstone:9>);
+recipes.remove(<ganyssurface:colouredRedstone:10>);
+recipes.remove(<ganyssurface:colouredRedstone:11>);
+recipes.remove(<ganyssurface:colouredRedstone:12>);
+recipes.remove(<ganyssurface:colouredRedstone:13>);
+recipes.remove(<ganyssurface:colouredRedstone:14>);
+recipes.remove(<ganyssurface:colouredRedstone:15>);


### PR DESCRIPTION
Exploit fix
- Removed redstone from Gany's Surface to fix an exploit for infinite redstone
