### PR TITLE
Treibstoffkosten für Personal Anchor erhöht

### DIFF
--- a/config/railcraft/railcraft.cfg
+++ b/config/railcraft/railcraft.cfg
@@ -30,7 +30,7 @@ anchors {
     # Entry Format: <modid>:<itemname>#<metadata>=<value>
     # Example: personal.fuel= minecraft:ender_pearl=12, minecraft:coal#0=4
     # 
-    S:personal.fuel=minecraft:ender_pearl=2
+    S:personal.fuel=minecraft:ender_pearl=1
 
     # 
     # change to print.locations=true to print Anchor locations to the log on startup


### PR DESCRIPTION
Die Laufzeit des Personal Anchors wurde von 12 Stunden pro Ender Perle auf 1 Stunde pro Ender Perle reduziert.

Mit Ender-Lily Seeds ist es möglich eine Perle innerhalb von 3 bis 80 Minuten ( je nach Untergrund ) zu züchten. Dementsprechend sollte die Personal Anchor Laufzeit generft werden, damit eine Ender-Lily Farm erst mit End Stone oder Ender Core als Untergrund + Personal Anchor autark laufen kann.

Grüße DerOli82
