### PR TITLE
Update PneumaticCraft.cfg

### DIFF
--- a/config/PneumaticCraft.cfg
+++ b/config/PneumaticCraft.cfg
@@ -13,7 +13,7 @@ general {
     # Loss percentage (on average) of Compressed Iron ingots/blocks when exposed to an explosion.
     I:"Compressed Iron Loss Percentage"=20
     B:"Enable Drone Suffocation Damage"=true
-    B:"Enable Update Checker"=true
+    B:"Enable Update Checker"=false
 
     # Villager ID used for the Mechanic Villager. Change when ID collides with an other mod which adds villagers.
     I:"Villager Mechanic ID"=125


### PR DESCRIPTION
Autor hat gebeten den Update Checker zu deaktivieren, er fliegt in der nächsten Version raus, weil er zuviel Traffic auf seiner Webseite verursacht hat. ^^ 

https://twitter.com/MineMaarten/status/514439073193549826
