### PR TITLE
Rollback Power Converter Config für IC2/GT

### DIFF
--- a/config/powerconverters/common.cfg
+++ b/config/powerconverters/common.cfg
@@ -18,8 +18,8 @@ powersystems {
     }
 
     ic2 {
-        D:internalEnergyPerInput=1800.0
-        D:internalEnergyPerOutput=2200.0
+        D:internalEnergyPerInput=4500.0
+        D:internalEnergyPerOutput=5500.0
     }
 
     rf {
@@ -40,8 +40,8 @@ powersystems {
     }
 
     gt {
-        D:internalEnergyPerInput=1800.0
-        D:internalEnergyPerOutput=2200.0
+        D:internalEnergyPerInput=4500.0
+        D:internalEnergyPerOutput=5500.0
     }
 
 }


### PR DESCRIPTION
Rollback auf die vorherige Einstellung für IC2 und GT.

Erklärung wie im Forum vorgerechnet:

Die Power Converters sind mit dem aktuellen 1:4 Verhältnis jenseits von gut und böse auch wenn das die Standard Einstellung sein soll haut das meiner Meinung nach bei uns so überhaupt nicht hin. Dazu zwei Low Tech Aufbauten die ich heute durchgetestet habe zur Verdeutlichung.

Beispiel 1 Lava:
1 Lava Bucket -> Geothermal Generator (IC2) -> 10.000 EU -> Power Converter -> 32.727 RF
1 Lava Bucket -> Magmatic Dynamo (TE) -> 180.000 RF -> Power Converter -> 36.827 EU

Der Magmatic Dynamo macht aus 1 Lava Bucket via Power Converters das 3,6 Fache an EU Energie trotz Verlustleistung und ist wesentlich einfacher herzustellen als der Geothermal Generator für den man mindestens den GT Bender benötigt ( Empty Cell )

Beispiel 2 Steam:
1 Stack Coal + Water -> Steam Dynamo -> 3.068.000 RF -> Power Converter -> 608.872 EU
1 Stack Coal + Water -> Large Bronze Boiler + Basic Steam Turbine -> 232.818 EU -> Power Converter -> 682.298 RF

Beim Gregtech Aufbau wäre zu erwähnen das der Large Bronze Boiler etwas überdimensioniert ist für eine einzige Basic Steam Turbine aber die kleinen Boiler (Small und High Pressure) sind hoffnungslos unterdimensioniert für eine Turbine.

Auch hier haben wir ungefähr das 3 Fache an Energie was der RF Steam Dynamo zum wesentlich aufwendigeren GT Aufbau ausspuckt.